### PR TITLE
Bug #53

### DIFF
--- a/src/banking/primitive/core/Checking.java
+++ b/src/banking/primitive/core/Checking.java
@@ -39,7 +39,7 @@ public class Checking extends Account {
 	public boolean withdraw(float amount) {
 		if (amount > 0.0f) {		
 			// KG: incorrect, last balance check should be >=
-			if (getState() == State.OPEN || (getState() == State.OVERDRAWN && balance > -100.0f)) {
+			if (getState() == State.OPEN || (getState() == State.OVERDRAWN && balance >= -100.0f)) {
 				balance = balance - amount;
 				numWithdraws++;
 				if (numWithdraws > 10)


### PR DESCRIPTION
Fix for Bug #53 - Checking.withdraw() did not allow a withdraw when the
balance was =-100.00. Since the threshold is for being overdrawn is
below -100.00, this was a fault.
